### PR TITLE
Added parameter to the method

### DIFF
--- a/caesar-code
+++ b/caesar-code
@@ -1,4 +1,4 @@
-def caesar ():
+def caesar(message):
     key=2
     mode="encrypt"
     SYMBOLS="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890.,/;"
@@ -18,8 +18,3 @@ def caesar ():
     else:
         translated=translated+symbol
     return translated
-message=input()
-print(caesar())
-f= open("cipher.txt","w+")
-f.write(caesar())
-f.close() 


### PR DESCRIPTION
There should only be the method that takes the appropriate parameter, so people can use it in their code.
The execution should then be done in the real program by calling the method and passing the message to it like this:

text = input()
print(caesar(text))